### PR TITLE
feat(next): added 'use client' annotation for better next support

### DIFF
--- a/src/components/core/button/index.tsx
+++ b/src/components/core/button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps, ReactNode } from 'react'
 import { MdFilledButton as _MdFilledButton } from '@material/web/button/filled-button.js'

--- a/src/components/core/checkbox/index.tsx
+++ b/src/components/core/checkbox/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdCheckbox as _MdCheckbox } from '@material/web/checkbox/checkbox.js'

--- a/src/components/core/chips/index.tsx
+++ b/src/components/core/chips/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdAssistChip as _MdAssistChip } from '@material/web/chips/assist-chip'

--- a/src/components/core/dialog/index.tsx
+++ b/src/components/core/dialog/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdDialog as _MdDialog } from '@material/web/dialog/dialog.js'

--- a/src/components/core/divider/index.tsx
+++ b/src/components/core/divider/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdDivider as _MdDivider } from '@material/web/divider/divider.js'

--- a/src/components/core/elevation/index.tsx
+++ b/src/components/core/elevation/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdElevation as _MdElevation } from '@material/web/elevation/elevation'

--- a/src/components/core/fab/index.tsx
+++ b/src/components/core/fab/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { FabSize, MdFab as _MdFab } from '@material/web/fab/fab.js'

--- a/src/components/core/focus-ring/index.tsx
+++ b/src/components/core/focus-ring/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdFocusRing as _MdFocusRing } from '@material/web/focus/md-focus-ring'

--- a/src/components/core/icon-button/index.tsx
+++ b/src/components/core/icon-button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { MdIconButton as _MdIconButton } from '@material/web/iconbutton/icon-button.js'
 import { MdFilledIconButton as _MdFilledIconButton } from '@material/web/iconbutton/filled-icon-button.js'
 import { MdOutlinedIconButton as _MdOutlinedIconButton } from '@material/web/iconbutton/outlined-icon-button.js'

--- a/src/components/core/icon/index.tsx
+++ b/src/components/core/icon/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import { MdIcon as _MdIcon } from '@material/web/icon/icon.js'
 import React, { ComponentProps } from 'react'

--- a/src/components/core/labs/card/index.tsx
+++ b/src/components/core/labs/card/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ComponentProps } from 'react'
 import { createComponent } from '@lit/react'
 import { MdFilledCard as _MdFilledCard } from '@material/web/labs/card/filled-card.js'

--- a/src/components/core/labs/navigation-bar/index.tsx
+++ b/src/components/core/labs/navigation-bar/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ComponentProps } from 'react'
 import { createComponent } from '@lit/react'
 import { MdNavigationBar as _MdNavigationBar } from '@material/web/labs/navigationbar/navigation-bar.js'

--- a/src/components/core/labs/segmented-button/index.tsx
+++ b/src/components/core/labs/segmented-button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ComponentProps } from 'react'
 import { createComponent } from '@lit/react'
 import { MdOutlinedSegmentedButton as _MdOutlinedSegmentedButton } from '@material/web/labs/segmentedbutton/outlined-segmented-button.js'

--- a/src/components/core/list/index.tsx
+++ b/src/components/core/list/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ComponentProps } from 'react'
 import { createComponent } from '@lit/react'
 import { MdList as _MdList } from '@material/web/list/list'

--- a/src/components/core/menu/index.tsx
+++ b/src/components/core/menu/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdMenu as _MdMenu } from '@material/web/menu/menu.js'

--- a/src/components/core/progress/index.tsx
+++ b/src/components/core/progress/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdCircularProgress as _MdCircularProgress } from '@material/web/progress/circular-progress.js'

--- a/src/components/core/radio/index.tsx
+++ b/src/components/core/radio/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdRadio as _MdRadio } from '@material/web/radio/radio.js'

--- a/src/components/core/ripple/index.tsx
+++ b/src/components/core/ripple/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React from 'react'
 

--- a/src/components/core/select/index.tsx
+++ b/src/components/core/select/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React from 'react'
 

--- a/src/components/core/slider/index.tsx
+++ b/src/components/core/slider/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React from 'react'
 

--- a/src/components/core/switch/index.tsx
+++ b/src/components/core/switch/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createComponent } from '@lit/react'
 import React, { ComponentProps } from 'react'
 import { MdSwitch as _MdSwitch } from '@material/web/switch/switch.js'

--- a/src/components/core/tabs/index.tsx
+++ b/src/components/core/tabs/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ComponentProps } from 'react'
 import { createComponent } from '@lit/react'
 import { MdTabs as _MdTabs } from '@material/web/tabs/tabs.js'

--- a/src/components/core/textfield/index.tsx
+++ b/src/components/core/textfield/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { ComponentProps } from 'react'
 import { createComponent } from '@lit/react'
 import { MdFilledTextField as _MdFilledTextField } from '@material/web/textfield/filled-text-field.js'


### PR DESCRIPTION
This PR adds the 'use client' annotation, allowing components to be used without the need to annotate parent components when using Next.js.