### PR TITLE
feat(badge): added badge component

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ or
 
 ### Labs 🚧
 > WARNING ⚠️ This folder contains experimental features that are not recommended for production.
+- ✅ Badge
 - ✅ Card
 - ✅ Segmented button
 - ✅ Navigation bar

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
         "webpack-dev-server": "^5.0.4"
     },
     "dependencies": {
-        "@fontsource/roboto": "^5.0.12",
-        "@lit/react": "^1.0.4",
-        "@material/web": "^2.0.0",
-        "material-symbols": "^0.17.4"
+        "@fontsource/roboto": "^5.1.0",
+        "@lit/react": "^1.0.5",
+        "@material/web": "^2.2.0",
+        "material-symbols": "^0.24.0"
     }
 }

--- a/src/components/core/index.tsx
+++ b/src/components/core/index.tsx
@@ -19,6 +19,7 @@ export * from './switch'
 export * from './tabs'
 export * from './textfield'
 
+export * from './labs/badge'
 export * from './labs/card'
 export * from './labs/segmented-button'
 export * from './labs/navigation-bar'

--- a/src/components/core/labs/badge/index.tsx
+++ b/src/components/core/labs/badge/index.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import React, { ComponentProps } from 'react'
+import { createComponent } from '@lit/react'
+import { MdBadge as _MdBadge } from '@material/web/labs/badge/badge.js'
+
+/**
+ * Props for the `MdBadge` component.
+ * This interface is used to provide the props for the `MdBadge` component.
+ *
+ */
+export type MdBadgeProps = ComponentProps<typeof MdBadge>
+
+export interface MdBadgeElement extends _MdBadge {
+}
+
+/**
+ * Material design badge component
+ * This component is a React wrapper around the `md-badge` custom element.
+ *
+ */
+export const MdBadge = createComponent({
+    react: React,
+    tagName: 'md-badge',
+    elementClass: _MdBadge,
+})

--- a/src/components/core/labs/badge/stories/md-badge.stories.tsx
+++ b/src/components/core/labs/badge/stories/md-badge.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { MdBadge, MdBadgeProps } from '..'
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+    title: 'Material You/Badge/Badge',
+    component: MdBadge,
+    parameters: {
+        // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+        layout: 'centered',
+    },
+    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+    tags: ['autodocs'],
+    // More on argTypes: https://storybook.js.org/docs/api/argtypes
+    argTypes: {
+        value: {
+            control: 'text',
+            description: 'The value to display in the badge.',
+            defaultValue: '123+',
+        },
+    },
+    // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+    args: {},
+} satisfies Meta<MdBadgeProps>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Detault: Story = {
+    args: {
+        value: '123+',
+    },
+    render: ({ ...props }) => {
+        return (
+            <MdBadge {...props} />
+        )
+    },
+}


### PR DESCRIPTION
This pull request includes several updates to the `labs` section and dependencies, as well as the addition of a new `MdBadge` component and its corresponding Storybook story. 

Changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86): Added the `Badge` component to the list of experimental features.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L68-R71): Updated dependencies for `@fontsource/roboto`, `@lit/react`, `@material/web`, and `material-symbols` to their latest versions.
* [`src/components/core/labs/badge/index.tsx`](diffhunk://#diff-20c190348fbf65ed8628a4c0ed3ae6a99859d6de9185d56c85545f8e7f80af23R1-R26): Introduced a new `MdBadge` component.
* [`src/components/core/labs/badge/stories/md-badge.stories.tsx`](diffhunk://#diff-a87f542d5947f811b1e27c19aa26db0a438d1ef110d5e3d2696ce4ba61a08e17R1-R41): Added a Storybook story for the new component.