### PR TITLE
chore(deps): bumb @lit/react version to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     },
     "dependencies": {
         "@fontsource/roboto": "^5.1.0",
-        "@lit/react": "^1.0.5",
+        "@lit/react": "^1.0.6",
         "@material/web": "^2.2.0",
         "material-symbols": "^0.24.0"
     }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version of the `@lit/react` dependency from `^1.0.5` to `^1.0.6`. In 1.0.5 there is a bug where if you are running the application in dev mode you are getting prototype errors. https://github.com/lit/lit/pull/4774

Also, I think maybe this could be automated trough dependabot?